### PR TITLE
[Nexus-1051] Router: Tunings tab advanced options

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,30 @@
 <template>
   <div id="app">
     <!-- <news-modal /> -->
-    <router-view />
+    <RouterView />
     <!-- <tutorial-modal
       :open="activeMenu"/> -->
 
-    <modal-depending-on-flows-length />
+    <ModalDependingOnFlowsLength />
 
-    <unnnic-alert
+    <UnnnicAlert
       v-if="$store.state.alert"
       :key="$store.state.alert.text"
       v-bind="$store.state.alert"
       @close="$store.state.alert = null"
-    ></unnnic-alert>
+    ></UnnnicAlert>
+
+    <ModalWarn
+      v-if="$store.state.modalWarn"
+      :showModal="!!$store.state.modalWarn"
+      :title="$store.state.modalWarn.title"
+      :description="$store.state.modalWarn.description"
+      :closeText="$store.state.modalWarn.closeText"
+      :actionText="$store.state.modalWarn.actionText"
+      :loading="$store.state.modalWarn.loading"
+      @close="$store.state.modalWarn = null"
+      @action="$store.state.modalWarn.action"
+    />
   </div>
 </template>
 
@@ -23,12 +35,14 @@ import hotjar from '@/utils/plugins/hotjar';
 import I18n from '@/utils/plugins/i18n';
 import store from './store';
 import ModalDependingOnFlowsLength from './components/ModalDependingOnFlowsLength';
+import ModalWarn from './components/ModalWarn.vue';
 
 export default {
   components: {
     NewsModal,
     I18n,
     ModalDependingOnFlowsLength,
+    ModalWarn,
   },
 
   name: 'App',
@@ -44,11 +58,11 @@ export default {
       if (I18n.locale === 'pt-BR') {
         return 'Weni Inteligência Artificial';
       }
-      if (I18n.locale === 'en-US'){
+      if (I18n.locale === 'en-US') {
         return 'Weni Artificial Intelligence';
       }
-      return 'Weni Inteligencia Artificial'
-    }
+      return 'Weni Inteligencia Artificial';
+    },
   },
   created() {
     window.addEventListener('message', (event) => {
@@ -92,28 +106,28 @@ export default {
     ...mapActions(['getMyProfileInfo', 'setUserName']),
     async profileInfo() {
       const { data } = await this.getMyProfileInfo();
-      if (data){
+      if (data) {
         this.$set(this.$store.state.User, 'me', data);
 
-        this.setUserName(data.name)
+        this.setUserName(data.name);
         if (data.language.includes('-')) {
           const [first, second] = data.language.split('-');
           const secondUpperCase = second.toUpperCase();
           const languageResult = `${first}-${secondUpperCase}`;
           this.$i18n.locale = languageResult;
         } else {
-          this.$i18n.locale = data.language
+          this.$i18n.locale = data.language;
         }
       }
-      return true
+      return true;
     },
     safariDetected() {
       if (
-        navigator.userAgent.indexOf('Safari') !== -1
-        && navigator.userAgent.indexOf('Chrome') === -1
+        navigator.userAgent.indexOf('Safari') !== -1 &&
+        navigator.userAgent.indexOf('Chrome') === -1
       ) {
         this.$router.push({
-          name: 'safari-alert'
+          name: 'safari-alert',
         });
       }
     },
@@ -126,10 +140,13 @@ export default {
       const debug = url.host && url.host.includes('develop');
 
       document.querySelectorAll('a[href]').forEach((link) => {
-        const internalHref = link.getAttribute('internal-href') || link.getAttribute('href');
+        const internalHref =
+          link.getAttribute('internal-href') || link.getAttribute('href');
 
         if (
-          ['http://', 'https://'].some((initial) => internalHref.startsWith(initial),)
+          ['http://', 'https://'].some((initial) =>
+            internalHref.startsWith(initial),
+          )
         ) {
           return;
         }
@@ -173,17 +190,16 @@ export default {
 </script>
 
 <style lang="scss">
-@import "~@/assets/scss/utilities.scss";
-@import "~@/assets/scss/default.scss";
-@import "~@/assets/scss/colors.scss";
-@import "~@/assets/scss/variables.scss";
-@import "~@weni/unnnic-system/dist/unnnic.css";
-@import "~@weni/unnnic-system/src/assets/scss/unnnic.scss";
+@import '~@/assets/scss/utilities.scss';
+@import '~@/assets/scss/default.scss';
+@import '~@/assets/scss/colors.scss';
+@import '~@/assets/scss/variables.scss';
+@import '~@weni/unnnic-system/dist/unnnic.css';
+@import '~@weni/unnnic-system/src/assets/scss/unnnic.scss';
 
 html:not(.not-bulma) {
-  @import "~bulma";
-  @import "~buefy/src/scss/buefy";
-
+  @import '~bulma';
+  @import '~buefy/src/scss/buefy';
 }
 
 body {
@@ -217,17 +233,17 @@ body {
 
 // based on https://flatuicolors.com/palette/nl
 $entities-colors: (
-  ("selected", $grey-lighter, black),
-  ("sunflower", #ffc312, black),
-  ("energos", #c4e538, black),
-  ("blue-martina", #12cbc4, black),
-  ("lavender-rose", #fda7df, black),
-  ("bara-red", #ed4c67, white),
-  ("radiant-yellow", #f79f1f, white),
-  ("android-green", #a3cb38, white),
-  ("mediterranean-sea", #1289a7, white),
-  ("lavender-tea", #d980fa, black),
-  ("very-berry", #b53471, white)
+  ('selected', $grey-lighter, black),
+  ('sunflower', #ffc312, black),
+  ('energos', #c4e538, black),
+  ('blue-martina', #12cbc4, black),
+  ('lavender-rose', #fda7df, black),
+  ('bara-red', #ed4c67, white),
+  ('radiant-yellow', #f79f1f, white),
+  ('android-green', #a3cb38, white),
+  ('mediterranean-sea', #1289a7, white),
+  ('lavender-tea', #d980fa, black),
+  ('very-berry', #b53471, white)
 );
 
 @each $entity-color in $entities-colors {

--- a/src/api/nexusaiAPI.js
+++ b/src/api/nexusaiAPI.js
@@ -279,6 +279,18 @@ export default {
           setup: others,
         });
       },
+
+      advanced: {
+        read({ projectUuid }) {
+          return request.$http.get(`api/${projectUuid}/project/`);
+        },
+
+        edit({ projectUuid, brain_on }) {
+          return request.$http.patch(`api/${projectUuid}/project/`, {
+            brain_on,
+          });
+        },
+      },
     },
   },
 

--- a/src/components/ModalWarn.vue
+++ b/src/components/ModalWarn.vue
@@ -3,10 +3,10 @@
     :showModal="showModal"
     scheme="aux-yellow-500"
     modalIcon="warning"
-    :text="$t('router.tunings.restore_default_modal.title')"
-    :description="$t('router.tunings.restore_default_modal.description')"
+    :text="title"
+    :description="description"
     :closeIcon="false"
-    class="restore-default-modal"
+    class="modal-warn"
   >
     <UnnnicButton
       slot="options"
@@ -14,17 +14,17 @@
       type="tertiary"
       @click="$emit('close')"
     >
-      {{ $t('router.tunings.restore_default_modal.cancel') }}
+      {{ closeText }}
     </UnnnicButton>
 
     <UnnnicButton
       slot="options"
       class="create-repository__container__button attention-button"
       type="attention"
-      :loading="restoring"
-      @click="$emit('restore')"
+      :loading="loading"
+      @click="$emit('action')"
     >
-      {{ $t('router.tunings.restore_default_modal.restore') }}
+      {{ actionText }}
     </UnnnicButton>
   </UnnnicModal>
 </template>
@@ -33,7 +33,11 @@
 export default {
   props: {
     showModal: Boolean,
-    restoring: Boolean,
+    loading: Boolean,
+    title: String,
+    description: String,
+    closeText: String,
+    actionText: String,
   },
 };
 </script>
@@ -41,7 +45,7 @@ export default {
 <style lang="scss" scoped>
 @import '~@weni/unnnic-system/src/assets/scss/unnnic.scss';
 
-.restore-default-modal
+.modal-warn
   ::v-deep
   .unnnic-modal-container-background-body-description-container {
   padding-bottom: $unnnic-spacing-xs;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -82,6 +82,12 @@
           "description": "Are you sure you want to activate Brain? This will cause your triggers to be replaced by Actions and this can directly affect the operation of your agent.",
           "cancel": "Cancel",
           "action": "Activate"
+        },
+        "deactivate_brain_modal": {
+          "title": "Deactivate Brain",
+          "description": "Are you sure you want to deactivate Brain? This will cause your actions to be replaced by triggers and this can directly affect the functioning of your bot.",
+          "cancel": "Cancel",
+          "action": "Deactivate"
         }
       }
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -72,6 +72,11 @@
         "top_p_info": "When you set the \"top P\" of an artificial intelligence model, you are adjusting how the model selects the next words during text generation",
         "top_k": "Top K",
         "top_k_info": "By setting the \"top K\" of an artificial intelligence model, you are determining how many of the most likely words the model will consider when choosing the next word during text generation"
+      },
+      "advanced": {
+        "title": "Advanced options",
+        "description": "This option can disable or enable your triggers.",
+        "brain": "Brain"
       }
     }
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -76,7 +76,13 @@
       "advanced": {
         "title": "Advanced options",
         "description": "This option can disable or enable your triggers.",
-        "brain": "Brain"
+        "brain": "Brain",
+        "active_brain_modal": {
+          "title": "Activate Brain",
+          "description": "Are you sure you want to activate Brain? This will cause your triggers to be replaced by Actions and this can directly affect the operation of your agent.",
+          "cancel": "Cancel",
+          "action": "Activate"
+        }
       }
     }
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -76,7 +76,13 @@
       "advanced": {
         "title": "Opciones avanzadas",
         "description": "Esta opción puede desactivar o activar tus activadores.",
-        "brain": "Brain"
+        "brain": "Brain",
+        "active_brain_modal": {
+          "title": "Activar Brain",
+          "description": "¿Estás seguro de que quieres activar Brain? Esto hará que tus activadores sean reemplazados por Acciones y esto puede afectar directamente al funcionamiento de tu agente",
+          "cancel": "Cancelar",
+          "action": "Activar"
+        }
       }
     }
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -82,6 +82,12 @@
           "description": "¿Estás seguro de que quieres activar Brain? Esto hará que tus activadores sean reemplazados por Acciones y esto puede afectar directamente al funcionamiento de tu agente",
           "cancel": "Cancelar",
           "action": "Activar"
+        },
+        "deactivate_brain_modal": {
+          "title": "Desactivar Brain",
+          "description": "¿Estás seguro de que quieres desactivar Brain? Esto hará que tus acciones sean reemplazadas por disparadores y esto puede afectar directamente al funcionamiento de tu bot.",
+          "cancel": "Cancelar",
+          "action": "Desactivar"
         }
       }
     }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -72,6 +72,11 @@
         "top_p_info": "Al ajustar el \"top P\" de un modelo de inteligencia artificial, está ajustando la forma en que el modelo selecciona las siguientes palabras durante la generación del texto",
         "top_k": "K superior",
         "top_k_info": "Al ajustar el \"top K\" de un modelo de inteligencia artificial, estás determinando cuántas de las palabras más probables considerará el modelo al elegir la siguiente palabra durante la generación del texto"
+      },
+      "advanced": {
+        "title": "Opciones avanzadas",
+        "description": "Esta opción puede desactivar o activar tus activadores.",
+        "brain": "Brain"
       }
     }
   },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -76,7 +76,13 @@
       "advanced": {
         "title": "Opções avançadas",
         "description": "Essa opção pode desativar ou ativar suas triggers.",
-        "brain": "Brain"
+        "brain": "Brain",
+        "active_brain_modal": {
+          "title": "Ativar Brain",
+          "description": "Tem certeza que deseja ativar o Brain? Isso fará com que suas triggers sejam substituídas pelas Ações e isso pode afetar diretamente o funcionamento do seu agente.",
+          "cancel": "Cancelar",
+          "action": "Ativar"
+        }
       }
     }
   },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -72,6 +72,11 @@
         "top_p_info": "Ao configurar o \"top P\" de um modelo de inteligência artificial, você está ajustando como o modelo seleciona as próximas palavras durante a geração de texto",
         "top_k": "Top K",
         "top_k_info": "Ao configurar o \"top K\" de um modelo de inteligência artificial, você está determinando quantas das palavras mais prováveis o modelo considerará ao escolher a próxima palavra durante a geração de texto."
+      },
+      "advanced": {
+        "title": "Opções avançadas",
+        "description": "Essa opção pode desativar ou ativar suas triggers.",
+        "brain": "Brain"
       }
     }
   },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -82,6 +82,12 @@
           "description": "Tem certeza que deseja ativar o Brain? Isso fará com que suas triggers sejam substituídas pelas Ações e isso pode afetar diretamente o funcionamento do seu agente.",
           "cancel": "Cancelar",
           "action": "Ativar"
+        },
+        "deactivate_brain_modal": {
+          "title": "Desativar Brain",
+          "description": "Tem certeza que deseja desativar o Brain? Isso fará com que suas ações serão substituidas pelas triggers e isso pode afetar diretamente o funcionamento do seu bot.",
+          "cancel": "Cancelar",
+          "action": "Desativar"
         }
       }
     }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -24,6 +24,8 @@ const store = new Vuex.Store({
   state: {
     alert: null,
 
+    modalWarn: null,
+
     router: {
       intelligenceUuid: null,
       contentBaseUuid: null,

--- a/src/views/repository/content/BasesForm.vue
+++ b/src/views/repository/content/BasesForm.vue
@@ -341,7 +341,7 @@ export default {
       },
 
       routerTunings: {
-        brainOn: false,
+        brainOn: true,
       },
     };
   },

--- a/src/views/repository/content/BasesForm.vue
+++ b/src/views/repository/content/BasesForm.vue
@@ -144,7 +144,10 @@
                 :items="routerActions"
               />
 
-              <RouterTunings v-else-if="$route.name === 'router-tunings'" />
+              <RouterTunings
+                v-else-if="$route.name === 'router-tunings'"
+                :data="routerTunings"
+              />
             </section>
           </section>
         </section>
@@ -335,6 +338,10 @@ export default {
       routerActions: {
         status: null,
         data: [],
+      },
+
+      routerTunings: {
+        brainOn: false,
       },
     };
   },

--- a/src/views/repository/content/BasesForm.vue
+++ b/src/views/repository/content/BasesForm.vue
@@ -341,7 +341,7 @@ export default {
       },
 
       routerTunings: {
-        brainOn: true,
+        brainOn: false,
       },
     };
   },
@@ -429,6 +429,14 @@ export default {
           this.sites.status = null;
         }
       }
+    },
+
+    async loadRouterOptions() {
+      const { data } = await nexusaiAPI.router.tunings.advanced.read({
+        projectUuid: this.$store.state.Auth.connectProjectUuid,
+      });
+
+      this.routerTunings.brainOn = data.brain_on;
     },
 
     alertError(title) {
@@ -655,6 +663,10 @@ export default {
 
     this.loadFiles();
     this.loadSites();
+
+    if (this.isRouterView) {
+      this.loadRouterOptions();
+    }
   },
 
   destroyed() {

--- a/src/views/repository/content/router/RouterTunings.vue
+++ b/src/views/repository/content/router/RouterTunings.vue
@@ -96,6 +96,8 @@
       />
     </template>
 
+    <RouterTuningsAdvanced class="tunings__advanced" />
+
     <UnnnicDivider ySpacing="md" />
 
     <footer class="tunings__actions">
@@ -126,10 +128,12 @@
 
 <script>
 import nexusaiAPI from '../../../../api/nexusaiAPI';
+import RouterTuningsAdvanced from './RouterTuningsAdvanced.vue';
 import RouterTuningsModalRestoreDefault from './RouterTuningsModalRestoreDefault.vue';
 
 export default {
   components: {
+    RouterTuningsAdvanced,
     RouterTuningsModalRestoreDefault,
   },
 
@@ -339,6 +343,10 @@ export default {
 
 .tunings__form-element__slider {
   max-width: 24 * $unnnic-font-size;
+}
+
+.tunings__advanced {
+  margin-top: $unnnic-spacing-md;
 }
 
 .tunings__actions {

--- a/src/views/repository/content/router/RouterTuningsAdvanced.vue
+++ b/src/views/repository/content/router/RouterTuningsAdvanced.vue
@@ -99,6 +99,23 @@ export default {
           loading: false,
           action: this.changeBrainOn.bind(this, true),
         };
+      } else {
+        this.$store.state.modalWarn = {
+          title: this.$t(
+            'router.tunings.advanced.deactivate_brain_modal.title',
+          ),
+          description: this.$t(
+            'router.tunings.advanced.deactivate_brain_modal.description',
+          ),
+          closeText: this.$t(
+            'router.tunings.advanced.deactivate_brain_modal.cancel',
+          ),
+          actionText: this.$t(
+            'router.tunings.advanced.deactivate_brain_modal.action',
+          ),
+          loading: false,
+          action: this.changeBrainOn.bind(this, false),
+        };
       }
     },
 

--- a/src/views/repository/content/router/RouterTuningsAdvanced.vue
+++ b/src/views/repository/content/router/RouterTuningsAdvanced.vue
@@ -1,0 +1,96 @@
+<template>
+  <section class="advanced">
+    <header
+      class="advanced__header"
+      @click="open = !open"
+    >
+      <UnnnicIntelligenceText
+        color="neutral-dark"
+        family="secondary"
+        weight="bold"
+        size="body-gt"
+      >
+        {{ $t('router.tunings.advanced.title') }}
+      </UnnnicIntelligenceText>
+
+      <UnnnicIcon
+        scheme="neutral-dark"
+        :icon="open ? 'expand_less' : 'expand_more'"
+        size="ant"
+        clickable
+      />
+    </header>
+
+    <section
+      v-show="open"
+      class="advanced__content"
+    >
+      <UnnnicIntelligenceText
+        color="neutral-cloudy"
+        family="secondary"
+        size="body-gt"
+        tag="p"
+      >
+        {{ $t('router.tunings.advanced.description') }}
+      </UnnnicIntelligenceText>
+
+      <UnnnicFormElement class="advanced__content__brain-switch">
+        <UnnnicSwitch
+          :textRight="$t('router.tunings.advanced.brain')"
+          :value="brain"
+          @input="brain = $event"
+        />
+      </UnnnicFormElement>
+    </section>
+  </section>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      open: false,
+
+      brain: true,
+    };
+  },
+
+  watch: {
+    open() {
+      if (this.open) {
+        this.$el.scrollIntoView({ behavior: 'smooth' });
+      }
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+@import '~@weni/unnnic-system/src/assets/scss/unnnic.scss';
+
+.advanced {
+  padding: $unnnic-spacing-sm;
+
+  outline-style: solid;
+  outline-color: $unnnic-color-neutral-cleanest;
+  outline-width: $unnnic-border-width-thinner;
+  outline-offset: -$unnnic-border-width-thinner;
+  border-radius: $unnnic-border-radius-md;
+
+  &__header {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+    column-gap: $unnnic-spacing-nano;
+  }
+
+  &__content {
+    margin-top: $unnnic-spacing-sm;
+
+    &__brain-switch {
+      margin-top: $unnnic-spacing-xs;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Advanced options in router tunings tab to active or deactivate Brain.

### Summary of Changes
<!--- Describe your changes in detail -->
* Adds advanced options component;
* Creates a generic modal warn to centralize all of its type;
* Adds active and deactivate warnings and its integrations.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Router - Tunings - Advanced Options](https://www.figma.com/file/QE22CBVh18ORmxe1HhDUkD/Router?type=design&node-id=320-2170&mode=design&t=Qpp2kZWfAP2FtOP8-0)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
![image](https://github.com/weni-ai/ia-platform-frontend/assets/6540136/c1ec1f63-7c8c-461b-95d3-51ea1816340b)
