### PR TITLE
fix(router): fixes model radio select when model came null

### DIFF
--- a/src/views/repository/content/router/RouterTunings.vue
+++ b/src/views/repository/content/router/RouterTunings.vue
@@ -291,8 +291,8 @@ export default {
     },
 
     setInitialValues(data) {
-      this.$set(this.oldValues, 'model', data.model);
-      this.$set(this.values, 'model', data.model);
+      this.$set(this.oldValues, 'model', data.model || this.values.model);
+      this.$set(this.values, 'model', data.model || this.values.model);
 
       const handleName = (name) =>
         name === 'version' && data.model === 'ChatGPT' ? 'version-gpt' : name;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Radio selection model from Router Tunings stoped when the value was null.

### Summary of Changes
<!--- Describe your changes in detail -->
* The null value has been treated to use de default value.