### PR TITLE
Nexus 1092 insert flow name in modal description

### DIFF
--- a/src/components/actions/ModalActions.vue
+++ b/src/components/actions/ModalActions.vue
@@ -44,6 +44,7 @@
                 : $t('modals.actions.descriptions.title')
             }}
           </h3>
+          <h4 v-if="index === 1">{{ flowSelected.name }}</h4>
           <p>
             {{
               index === 0
@@ -272,6 +273,7 @@ export default {
         uuid: value?.uuid || '',
       };
       this.flowSelected = flow;
+      this.$emit('flowSelected', flow)
     },
     handleFlowName(str) {
       return str.length > 30 ? str.slice(0, 27) + '...' : str;

--- a/src/components/actions/ModalActions.vue
+++ b/src/components/actions/ModalActions.vue
@@ -273,7 +273,6 @@ export default {
         uuid: value?.uuid || '',
       };
       this.flowSelected = flow;
-      this.$emit('flowSelected', flow)
     },
     handleFlowName(str) {
       return str.length > 30 ? str.slice(0, 27) + '...' : str;

--- a/src/components/actions/ModalChangeAction.vue
+++ b/src/components/actions/ModalChangeAction.vue
@@ -7,6 +7,7 @@
       <header class="flow-modal__header">
         <section class="flow-modal__header__title__container">
           <h3>{{ $t('modals.actions.descriptions.change_title') }}</h3>
+          <h4 v-if="item">{{ item }}</h4>
           <p>{{ $t('modals.actions.descriptions.change_sub_title') }}</p>
         </section>
       </header>
@@ -51,6 +52,7 @@ export default {
   },
   props: {
     description: String,
+    item: String,
     editing: Boolean,
   },
   data() {

--- a/src/views/repository/content/router/RouterActions.vue
+++ b/src/views/repository/content/router/RouterActions.vue
@@ -22,12 +22,14 @@
       :saving="isAdding"
       @closeModal="isAddActionOpen = false"
       @save="saveAction"
+      @flowSelected="handleSelectedFlow"
     />
 
     <ModalChangeAction
       v-if="modalEditAction"
       :editing="modalEditAction.status === 'editing'"
       :description.sync="modalEditAction.description"
+      :item="flowName"
       @closeModal="modalEditAction = null"
       @edit="editAction"
     />
@@ -72,6 +74,7 @@ export default {
 
       modalEditAction: null,
       modalDeleteAction: null,
+      flowName: null,
     };
   },
 
@@ -199,6 +202,9 @@ export default {
         this.isAdding = false;
       }
     },
+    handleSelectedFlow(flow) {
+      this.flowName = flow.name || ''
+    }
   },
 };
 </script>

--- a/src/views/repository/content/router/RouterActions.vue
+++ b/src/views/repository/content/router/RouterActions.vue
@@ -22,14 +22,13 @@
       :saving="isAdding"
       @closeModal="isAddActionOpen = false"
       @save="saveAction"
-      @flowSelected="handleSelectedFlow"
     />
 
     <ModalChangeAction
       v-if="modalEditAction"
       :editing="modalEditAction.status === 'editing'"
       :description.sync="modalEditAction.description"
-      :item="flowName"
+      :item="modalEditAction.name"
       @closeModal="modalEditAction = null"
       @edit="editAction"
     />
@@ -201,9 +200,6 @@ export default {
         this.isAddActionOpen = false;
         this.isAdding = false;
       }
-    },
-    handleSelectedFlow(flow) {
-      this.flowName = flow.name || ''
     }
   },
 };


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
old:
![image](https://github.com/weni-ai/ia-platform-frontend/assets/34746557/5c6e0fff-ba06-4907-85c1-9831a362832b)
![image](https://github.com/weni-ai/ia-platform-frontend/assets/34746557/ba57051d-fc98-45e6-bd2b-d328421adf34)


new:
![image](https://github.com/weni-ai/ia-platform-frontend/assets/34746557/da69898f-282a-45a9-9c5b-c4401da1adcc)
![image](https://github.com/weni-ai/ia-platform-frontend/assets/34746557/909f2b01-fe9f-47fb-81a4-69a7e4d53d37)


### Summary of Changes

- Logic to render flowName in description section

