### PR TITLE
[Nexus-1386] Bug: First Navigation to LoginExternal Page

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -100,9 +100,9 @@ const router = new Router({
 
         if (nextPath) {
           nextFromRedirect = to.query.next_from_redirect;
-          next(nextPath);
+          next({ path: nextPath, replace: true });
         } else {
-          next('/home');
+          next({ path: '/home', replace: true });
         }
       },
     },


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When user wants to back on navigation page for the first page loaded in Intelligences, the user received the not found page wrongly.