### PR TITLE
[NEXUS-2061] - Fix of spanish translation of "Run test"

### DIFF
--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -464,7 +464,7 @@
       "historic_title": "Historia de las pruebas manuales",
       "header_title_p2": "Usando nuestra función de prueba, puede evaluar el rendimiento de su inteligencia fácilmente.",
       "header_title_lang": "Seleccione el idioma para ejecutar la prueba.",
-      "run_test": "Prueba prueba",
+      "run_test": "Ejecutar prueba",
       "login": "Inicia sesión en tu cuenta para editar esta inteligencia.",
       "get_examples_test_sentences": "{n} frase de prueba | {n} frases de prueba",
       "add_new_test_sentence": "Añadir una nueva oración de prueba",


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [x] Other

### Motivation and Context
Spanish translation of "Run test" is wrong.

### Summary of Changes
Updated spanish translation of "run test".
